### PR TITLE
Add counter clockwise and different turns

### DIFF
--- a/app/src/main/java/com/rickyhu/hushkeyboard/HushKeyboardView.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/HushKeyboardView.kt
@@ -4,8 +4,11 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.AbstractComposeView
 import com.rickyhu.hushkeyboard.ui.composables.HushKeyboard
+import com.rickyhu.hushkeyboard.viewmodel.KeyboardViewModel
 
 class HushKeyboardView(context: Context) : AbstractComposeView(context) {
+    private var viewModel = KeyboardViewModel()
+
     @Composable
-    override fun Content() = HushKeyboard()
+    override fun Content() = HushKeyboard(viewModel)
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/ControlKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/ControlKeyButton.kt
@@ -1,0 +1,33 @@
+package com.rickyhu.hushkeyboard.ui.composables
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
+
+@Composable
+fun ControlKeyButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit
+) {
+    KeyButton(
+        modifier = modifier.clickable(onClick = onClick),
+        text = text
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ControlKeyButtonPreview() {
+    HushKeyboardTheme {
+        ControlKeyButton(
+            modifier = Modifier.size(48.dp),
+            text = "'",
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -1,5 +1,6 @@
 package com.rickyhu.hushkeyboard.ui.composables
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,37 +8,75 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
 import com.rickyhu.hushkeyboard.model.Notation
+import com.rickyhu.hushkeyboard.viewmodel.KeyboardViewModel
 
 @Composable
-fun HushKeyboard() {
+fun HushKeyboard(viewModel: KeyboardViewModel) {
+    val state by viewModel.keyboardState.collectAsState()
+
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
         val keyboardKeys = listOf(
             listOf(
-                CubeKey(Notation.R),
-                CubeKey(Notation.U),
-                CubeKey(Notation.F),
-                CubeKey(Notation.L),
-                CubeKey(Notation.D),
-                CubeKey(Notation.B)
+                CubeKey(Notation.R, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.U, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.F, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.L, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.D, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.B, state.isCounterClockwise, state.turns, state.isWideTurn)
             ),
             listOf(
-                CubeKey(Notation.M),
-                CubeKey(Notation.E),
-                CubeKey(Notation.S),
-                CubeKey(Notation.X),
-                CubeKey(Notation.Y),
-                CubeKey(Notation.Z)
+                CubeKey(Notation.M, state.isCounterClockwise, state.turns),
+                CubeKey(Notation.E, state.isCounterClockwise, state.turns),
+                CubeKey(Notation.S, state.isCounterClockwise, state.turns),
+                CubeKey(Notation.X, state.isCounterClockwise, state.turns),
+                CubeKey(Notation.Y, state.isCounterClockwise, state.turns),
+                CubeKey(Notation.Z, state.isCounterClockwise, state.turns)
             )
         )
 
         for (keysRow in keyboardKeys) {
             KeyButtonsRow(keysRow)
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            KeyButton(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(48.dp)
+                    .clickable(
+                        onClick = { viewModel.switchCounterClockwise() }
+                    ),
+                text = "'"
+            )
+            KeyButton(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(48.dp)
+                    .clickable(
+                        onClick = { viewModel.switchTurns() }
+                    ),
+                text = state.turns.value.toString()
+            )
+            KeyButton(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(48.dp)
+                    .clickable(
+                        onClick = { viewModel.switchWideTurn() }
+                    ),
+                text = "w"
+            )
         }
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -10,14 +10,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
 import com.rickyhu.hushkeyboard.model.Notation
+import com.rickyhu.hushkeyboard.service.HushIMEService
 import com.rickyhu.hushkeyboard.viewmodel.KeyboardViewModel
 
 @Composable
 fun HushKeyboard(viewModel: KeyboardViewModel) {
     val state by viewModel.keyboardState.collectAsState()
+    val context = LocalContext.current
 
     Column(
         modifier = Modifier.fillMaxWidth()
@@ -67,6 +70,14 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
                 modifier = controlKeyModifier,
                 text = "w",
                 onClick = viewModel::switchWideTurn
+            )
+            ControlKeyButton(
+                modifier = controlKeyModifier,
+                text = "⌫",
+                onClick = {
+                    val service = context as HushIMEService
+                    viewModel.deleteText(service.currentInputConnection)
+                }
             )
         }
     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
 import com.rickyhu.hushkeyboard.model.Notation
 
@@ -45,6 +48,13 @@ fun KeyButtonsRow(keys: List<CubeKey>) {
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
     ) {
-        keys.forEach { key -> KeyButton(key) }
+        keys.forEach { key ->
+            NotationKeyButton(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(48.dp),
+                key = key
+            )
+        }
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -45,7 +45,13 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
         )
 
         for (keysRow in keyboardKeys) {
-            NotationKeyButtonsRow(keysRow)
+            NotationKeyButtonsRow(
+                keys = keysRow,
+                onTextInput = { text ->
+                    val service = context as HushIMEService
+                    viewModel.inputText(service.currentInputConnection, text)
+                }
+            )
         }
 
         Row(
@@ -84,7 +90,10 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
 }
 
 @Composable
-private fun NotationKeyButtonsRow(keys: List<CubeKey>) {
+private fun NotationKeyButtonsRow(
+    keys: List<CubeKey>,
+    onTextInput: (String) -> Unit
+) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
@@ -94,7 +103,8 @@ private fun NotationKeyButtonsRow(keys: List<CubeKey>) {
                 modifier = Modifier
                     .padding(4.dp)
                     .size(48.dp),
-                cubeKey = key
+                cubeKey = key,
+                onTextInput = onTextInput
             )
         }
     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -83,7 +83,7 @@ private fun NotationKeyButtonsRow(keys: List<CubeKey>) {
                 modifier = Modifier
                     .padding(4.dp)
                     .size(48.dp),
-                key = key
+                cubeKey = key
             )
         }
     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -1,6 +1,5 @@
 package com.rickyhu.hushkeyboard.ui.composables
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -43,46 +42,38 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
         )
 
         for (keysRow in keyboardKeys) {
-            KeyButtonsRow(keysRow)
+            NotationKeyButtonsRow(keysRow)
         }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.Center
         ) {
-            KeyButton(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .size(48.dp)
-                    .clickable(
-                        onClick = { viewModel.switchCounterClockwise() }
-                    ),
-                text = "'"
+            val controlKeyModifier = Modifier
+                .padding(4.dp)
+                .size(48.dp)
+
+            ControlKeyButton(
+                modifier = controlKeyModifier,
+                text = "'",
+                onClick = viewModel::switchCounterClockwise
             )
-            KeyButton(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .size(48.dp)
-                    .clickable(
-                        onClick = { viewModel.switchTurns() }
-                    ),
-                text = state.turns.value.toString()
+            ControlKeyButton(
+                modifier = controlKeyModifier,
+                text = state.turns.value.toString(),
+                onClick = viewModel::switchTurns
             )
-            KeyButton(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .size(48.dp)
-                    .clickable(
-                        onClick = { viewModel.switchWideTurn() }
-                    ),
-                text = "w"
+            ControlKeyButton(
+                modifier = controlKeyModifier,
+                text = "w",
+                onClick = viewModel::switchWideTurn
             )
         }
     }
 }
 
 @Composable
-fun KeyButtonsRow(keys: List<CubeKey>) {
+private fun NotationKeyButtonsRow(keys: List<CubeKey>) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/KeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/KeyButton.kt
@@ -7,68 +7,28 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.rickyhu.hushkeyboard.model.CubeKey
-import com.rickyhu.hushkeyboard.model.Notation
-import com.rickyhu.hushkeyboard.model.Turns
-import com.rickyhu.hushkeyboard.service.HushIMEService
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
 @Composable
-fun KeyButton(key: CubeKey) {
-    val context = LocalContext.current
-    var inputKey by remember { mutableStateOf(key) }
-
-    Card(
-        modifier = Modifier
-            .padding(4.dp)
-            .size(48.dp)
-            .pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        val position = event.changes.first().position
-
-                        when (event.type.toString()) {
-                            "Press" -> {
-                                inputKey = key
-                            }
-
-                            "Move" -> {
-                                inputKey = if (position.x < 0) {
-                                    key.copy(isCounterClockwise = true)
-                                } else {
-                                    key.copy(turns = Turns.Double)
-                                }
-                            }
-
-                            "Release" -> {
-                                val service = context as HushIMEService
-                                val text = "$inputKey "
-                                service.currentInputConnection.commitText(text, text.length)
-                            }
-                        }
-                    }
-                }
-            }
-    ) {
+fun KeyButton(
+    modifier: Modifier = Modifier,
+    text: String
+) {
+    Card(modifier = modifier) {
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(4.dp),
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = key.toString(),
+                text = text,
                 textAlign = TextAlign.Center,
                 fontSize = 24.sp
             )
@@ -80,6 +40,9 @@ fun KeyButton(key: CubeKey) {
 @Composable
 fun KeyButtonPreview() {
     HushKeyboardTheme {
-        KeyButton(CubeKey(Notation.R))
+        KeyButton(
+            modifier = Modifier.size(48.dp),
+            text = "R"
+        )
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/KeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/KeyButton.kt
@@ -29,8 +29,8 @@ fun KeyButton(
         ) {
             Text(
                 text = text,
-                textAlign = TextAlign.Center,
-                fontSize = 24.sp
+                fontSize = 18.sp,
+                textAlign = TextAlign.Center
             )
         }
     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -21,14 +22,15 @@ import kotlin.math.abs
 @Composable
 fun NotationKeyButton(
     modifier: Modifier = Modifier,
-    key: CubeKey
+    cubeKey: CubeKey
 ) {
     val context = LocalContext.current
+    val key by rememberUpdatedState(cubeKey)
     var inputKey by remember { mutableStateOf(key) }
 
     KeyButton(
         modifier = modifier
-            .pointerInput(Unit) {
+            .pointerInput(key) {
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent()
@@ -80,7 +82,7 @@ fun NotationKeyButtonPreview() {
     HushKeyboardTheme {
         NotationKeyButton(
             modifier = Modifier.size(48.dp),
-            key = CubeKey(
+            cubeKey = CubeKey(
                 notation = Notation.R
             )
         )

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -66,7 +66,6 @@ fun NotationKeyButton(
                                 val service = context as HushIMEService
                                 val text = "$inputKey "
                                 service.currentInputConnection.commitText(text, text.length)
-                                val c = service.currentInputConnection
                             }
                         }
                     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -9,22 +9,20 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
 import com.rickyhu.hushkeyboard.model.Notation
 import com.rickyhu.hushkeyboard.model.Turns
-import com.rickyhu.hushkeyboard.service.HushIMEService
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 import kotlin.math.abs
 
 @Composable
 fun NotationKeyButton(
     modifier: Modifier = Modifier,
-    cubeKey: CubeKey
+    cubeKey: CubeKey,
+    onTextInput: (String) -> Unit = {}
 ) {
-    val context = LocalContext.current
     val key by rememberUpdatedState(cubeKey)
     var inputKey by remember { mutableStateOf(key) }
 
@@ -63,9 +61,7 @@ fun NotationKeyButton(
                             }
 
                             "Release" -> {
-                                val service = context as HushIMEService
-                                val text = "$inputKey "
-                                service.currentInputConnection.commitText(text, text.length)
+                                onTextInput("$inputKey ")
                             }
                         }
                     }
@@ -81,9 +77,7 @@ fun NotationKeyButtonPreview() {
     HushKeyboardTheme {
         NotationKeyButton(
             modifier = Modifier.size(48.dp),
-            cubeKey = CubeKey(
-                notation = Notation.R
-            )
+            cubeKey = CubeKey(notation = Notation.R)
         )
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -1,0 +1,73 @@
+package com.rickyhu.hushkeyboard.ui.composables
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.rickyhu.hushkeyboard.model.CubeKey
+import com.rickyhu.hushkeyboard.model.Notation
+import com.rickyhu.hushkeyboard.model.Turns
+import com.rickyhu.hushkeyboard.service.HushIMEService
+import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
+
+@Composable
+fun NotationKeyButton(
+    modifier: Modifier = Modifier,
+    key: CubeKey
+) {
+    val context = LocalContext.current
+    var inputKey by remember { mutableStateOf(key) }
+
+    KeyButton(
+        modifier = modifier
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        val position = event.changes.first().position
+
+                        when (event.type.toString()) {
+                            "Press" -> {
+                                inputKey = key
+                            }
+
+                            "Move" -> {
+                                inputKey = if (position.x < 0) {
+                                    key.copy(isCounterClockwise = true)
+                                } else {
+                                    key.copy(turns = Turns.Double)
+                                }
+                            }
+
+                            "Release" -> {
+                                val service = context as HushIMEService
+                                val text = "$inputKey "
+                                service.currentInputConnection.commitText(text, text.length)
+                            }
+                        }
+                    }
+                }
+            },
+        text = key.toString()
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NotationKeyButtonPreview() {
+    HushKeyboardTheme {
+        NotationKeyButton(
+            modifier = Modifier.size(48.dp),
+            key = CubeKey(
+                notation = Notation.R
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -16,6 +16,7 @@ import com.rickyhu.hushkeyboard.model.Notation
 import com.rickyhu.hushkeyboard.model.Turns
 import com.rickyhu.hushkeyboard.service.HushIMEService
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
+import kotlin.math.abs
 
 @Composable
 fun NotationKeyButton(
@@ -39,10 +40,23 @@ fun NotationKeyButton(
                             }
 
                             "Move" -> {
-                                inputKey = if (position.x < 0) {
-                                    key.copy(isCounterClockwise = true)
+                                if (abs(position.x) < abs(position.y)) {
+                                    // Notate as double turn when swiping up or down, but only
+                                    // if the key state is originally a single turn.
+                                    val turns = if (key.turns == Turns.Single) {
+                                        Turns.Double
+                                    } else {
+                                        key.turns
+                                    }
+
+                                    // Clockwise down, counter-clockwise up.
+                                    inputKey = key.copy(
+                                        isCounterClockwise = position.y < 0,
+                                        turns = turns
+                                    )
                                 } else {
-                                    key.copy(turns = Turns.Double)
+                                    // Clockwise right, counter-clockwise left.
+                                    inputKey = key.copy(isCounterClockwise = position.x < 0)
                                 }
                             }
 
@@ -50,6 +64,7 @@ fun NotationKeyButton(
                                 val service = context as HushIMEService
                                 val text = "$inputKey "
                                 service.currentInputConnection.commitText(text, text.length)
+                                val c = service.currentInputConnection
                             }
                         }
                     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
@@ -42,6 +42,10 @@ class KeyboardViewModel : ViewModel() {
             inputConnection.commitText("", 1)
         }
     }
+
+    fun inputText(inputConnection: InputConnection, text: String) {
+        inputConnection.commitText(text, text.length)
+    }
 }
 
 data class KeyboardState(

--- a/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
@@ -1,0 +1,40 @@
+package com.rickyhu.hushkeyboard.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.rickyhu.hushkeyboard.model.Turns
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class KeyboardViewModel : ViewModel() {
+    private val _keyboardState = MutableStateFlow(KeyboardState())
+    val keyboardState = _keyboardState.asStateFlow()
+
+    fun switchCounterClockwise() {
+        _keyboardState.update { state ->
+            state.copy(isCounterClockwise = !state.isCounterClockwise)
+        }
+    }
+
+    fun switchTurns() {
+        _keyboardState.update { state ->
+            when (state.turns) {
+                Turns.Single -> state.copy(turns = Turns.Double)
+                Turns.Double -> state.copy(turns = Turns.Triple)
+                Turns.Triple -> state.copy(turns = Turns.Single)
+            }
+        }
+    }
+
+    fun switchWideTurn() {
+        _keyboardState.update { state ->
+            state.copy(isWideTurn = !state.isWideTurn)
+        }
+    }
+}
+
+data class KeyboardState(
+    val isCounterClockwise: Boolean = false,
+    val turns: Turns = Turns.Single,
+    val isWideTurn: Boolean = false
+)

--- a/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
@@ -1,5 +1,7 @@
 package com.rickyhu.hushkeyboard.viewmodel
 
+import android.text.TextUtils
+import android.view.inputmethod.InputConnection
 import androidx.lifecycle.ViewModel
 import com.rickyhu.hushkeyboard.model.Turns
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +31,15 @@ class KeyboardViewModel : ViewModel() {
     fun switchWideTurn() {
         _keyboardState.update { state ->
             state.copy(isWideTurn = !state.isWideTurn)
+        }
+    }
+
+    fun deleteText(inputConnection: InputConnection) {
+        val selectedText = inputConnection.getSelectedText(0)
+        if (TextUtils.isEmpty(selectedText)) {
+            inputConnection.deleteSurroundingText(1, 0)
+        } else {
+            inputConnection.commitText("", 1)
         }
     }
 }


### PR DESCRIPTION
## Description

### Control Key Buttons

This PR adds the third row of buttons, which include:
- Counter clockwise button `'`
- Double and triple turns button `2` `3`
- Wide turn button `w`
- Delete button (supports single char delete, selected text delete)

### Notation Key Buttons

This PR also modifies the gesture direction of `NotationKeyButton`, the current spec is:
- Tap: Single clockwise (e.g. `R`)
- Swipe right: Single clockwise (e.g. `R`)
- Swipe left: Single counter-clockwise (e.g. `R'`)
- Swipe down: Double clockwise (e.g. `R2`)
- Swipe up: Double counter-clockwise (e.g. `R2'`)

## How to verify

- Case 1: `NotationKeyButton`s behaves taps and swipes correctly.
- Case 2: `ControlKeyButton`s can update `NotationKeyButton`s correctly.
- Case 3: `NotationKeyButton`s can behave taps correctly after `ControlKeyButton`s change its state.
- Case 4: Delete button can remove text expectedly.

## Screenshots / Videos

### Case 1

https://github.com/ricky9667/HushKeyboard/assets/55730003/79b1e334-9a8a-4511-938e-75e2b182005b

### Case 2

https://github.com/ricky9667/HushKeyboard/assets/55730003/c06605d7-05ba-4550-8cfa-8b242234c929

### Case 3

https://github.com/ricky9667/HushKeyboard/assets/55730003/ff9ff8b0-893c-4051-8364-bc3e50c43752

### Case 4

https://github.com/ricky9667/HushKeyboard/assets/55730003/d3db2ff2-7366-46d5-a65f-33892596dcdb


