### PR TITLE
Add notation key button tooltip

### DIFF
--- a/app/src/main/java/com/rickyhu/hushkeyboard/HushKeyboardView.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/HushKeyboardView.kt
@@ -1,6 +1,8 @@
 package com.rickyhu.hushkeyboard
 
 import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.AbstractComposeView
 import com.rickyhu.hushkeyboard.ui.composables.HushKeyboard
@@ -9,6 +11,7 @@ import com.rickyhu.hushkeyboard.viewmodel.KeyboardViewModel
 class HushKeyboardView(context: Context) : AbstractComposeView(context) {
     private var viewModel = KeyboardViewModel()
 
+    @RequiresApi(Build.VERSION_CODES.S)
     @Composable
     override fun Content() = HushKeyboard(viewModel)
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -2,21 +2,16 @@ package com.rickyhu.hushkeyboard.ui.composables
 
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
@@ -32,7 +27,7 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .border(BorderStroke(1.dp, Color.Gray))
+            .padding(vertical = 32.dp)
     ) {
         val keyboardKeys = listOf(
             listOf(
@@ -78,8 +73,6 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
             )
         )
 
-        Spacer(Modifier.height(24.dp))
-
         for (keysRow in keyboardKeys) {
             NotationKeyButtonsRow(
                 keys = keysRow,
@@ -116,8 +109,6 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
                 onClick = { viewModel.deleteText(context) }
             )
         }
-
-        Spacer(Modifier.height(24.dp))
     }
 }
 

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -31,36 +31,11 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
     ) {
         val keyboardKeys = listOf(
             listOf(
-                CubeKey(
-                    Notation.R,
-                    state.isCounterClockwise,
-                    state.turns,
-                    state.isWideTurn
-                ),
-                CubeKey(
-                    Notation.U,
-                    state.isCounterClockwise,
-                    state.turns,
-                    state.isWideTurn
-                ),
-                CubeKey(
-                    Notation.F,
-                    state.isCounterClockwise,
-                    state.turns,
-                    state.isWideTurn
-                ),
-                CubeKey(
-                    Notation.L,
-                    state.isCounterClockwise,
-                    state.turns,
-                    state.isWideTurn
-                ),
-                CubeKey(
-                    Notation.D,
-                    state.isCounterClockwise,
-                    state.turns,
-                    state.isWideTurn
-                ),
+                CubeKey(Notation.R, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.U, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.F, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.L, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(Notation.D, state.isCounterClockwise, state.turns, state.isWideTurn),
                 CubeKey(Notation.B, state.isCounterClockwise, state.turns, state.isWideTurn)
             ),
             listOf(

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/HushKeyboard.kt
@@ -2,16 +2,21 @@ package com.rickyhu.hushkeyboard.ui.composables
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
@@ -25,15 +30,42 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
     val context = LocalContext.current
 
     Column(
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(BorderStroke(1.dp, Color.Gray))
     ) {
         val keyboardKeys = listOf(
             listOf(
-                CubeKey(Notation.R, state.isCounterClockwise, state.turns, state.isWideTurn),
-                CubeKey(Notation.U, state.isCounterClockwise, state.turns, state.isWideTurn),
-                CubeKey(Notation.F, state.isCounterClockwise, state.turns, state.isWideTurn),
-                CubeKey(Notation.L, state.isCounterClockwise, state.turns, state.isWideTurn),
-                CubeKey(Notation.D, state.isCounterClockwise, state.turns, state.isWideTurn),
+                CubeKey(
+                    Notation.R,
+                    state.isCounterClockwise,
+                    state.turns,
+                    state.isWideTurn
+                ),
+                CubeKey(
+                    Notation.U,
+                    state.isCounterClockwise,
+                    state.turns,
+                    state.isWideTurn
+                ),
+                CubeKey(
+                    Notation.F,
+                    state.isCounterClockwise,
+                    state.turns,
+                    state.isWideTurn
+                ),
+                CubeKey(
+                    Notation.L,
+                    state.isCounterClockwise,
+                    state.turns,
+                    state.isWideTurn
+                ),
+                CubeKey(
+                    Notation.D,
+                    state.isCounterClockwise,
+                    state.turns,
+                    state.isWideTurn
+                ),
                 CubeKey(Notation.B, state.isCounterClockwise, state.turns, state.isWideTurn)
             ),
             listOf(
@@ -45,6 +77,8 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
                 CubeKey(Notation.Z, state.isCounterClockwise, state.turns)
             )
         )
+
+        Spacer(Modifier.height(24.dp))
 
         for (keysRow in keyboardKeys) {
             NotationKeyButtonsRow(
@@ -82,6 +116,8 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
                 onClick = { viewModel.deleteText(context) }
             )
         }
+
+        Spacer(Modifier.height(24.dp))
     }
 }
 

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -96,10 +96,9 @@ fun NotationKeyButton(
             text = key.toString()
         )
 
-        if (isPressed) {
-            KeyTooltip(text = key.toString(), modifier = modifier)
-        } else if (isDragged) {
-            KeyTooltip(text = inputKey.toString(), modifier = modifier)
+        when {
+            isPressed -> KeyTooltip(text = key.toString(), modifier = modifier)
+            isDragged -> KeyTooltip(text = inputKey.toString(), modifier = modifier)
         }
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,13 +40,18 @@ fun NotationKeyButton(
     val key by rememberUpdatedState(cubeKey)
     var inputKey by remember { mutableStateOf(key) }
 
+    LaunchedEffect(key) {
+        inputKey = key
+    }
+
     Box {
         KeyButton(
             modifier = modifier
-                .clickable(interactionSource = interactionSource, indication = null) {
-                    inputKey = key
-                    onTextInput("$inputKey ")
-                }
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = { onTextInput("$inputKey ") }
+                )
                 .draggable(
                     interactionSource = interactionSource,
                     orientation = Orientation.Horizontal,
@@ -80,7 +86,7 @@ fun NotationKeyButton(
         )
 
         if (isPressed || isDragged) {
-            Text(text = inputKey.toString())
+            Text(text = key.toString())
         }
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,9 +19,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.rickyhu.hushkeyboard.model.CubeKey
 import com.rickyhu.hushkeyboard.model.Notation
 import com.rickyhu.hushkeyboard.model.Turns
@@ -44,7 +49,9 @@ fun NotationKeyButton(
         inputKey = key
     }
 
-    Box {
+    Box(
+        contentAlignment = Alignment.Center
+    ) {
         KeyButton(
             modifier = modifier
                 .clickable(
@@ -86,11 +93,24 @@ fun NotationKeyButton(
         )
 
         if (isPressed) {
-            Text(text = key.toString())
+            KeyTooltip(text = key.toString(), modifier = modifier)
         } else if (isDragged) {
-            Text(text = inputKey.toString())
+            KeyTooltip(text = inputKey.toString(), modifier = modifier)
         }
     }
+}
+
+@Composable
+private fun KeyTooltip(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        fontSize = 18.sp,
+        textAlign = TextAlign.Center,
+        modifier = modifier.offset(y = (-32).dp)
+    )
 }
 
 @Preview(showBackground = true)
@@ -98,7 +118,9 @@ fun NotationKeyButton(
 fun NotationKeyButtonPreview() {
     HushKeyboardTheme {
         NotationKeyButton(
-            modifier = Modifier.size(48.dp),
+            modifier = Modifier
+                .padding(4.dp)
+                .size(48.dp),
             cubeKey = CubeKey(notation = Notation.R)
         )
     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -8,9 +8,13 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -105,12 +109,24 @@ private fun KeyTooltip(
     text: String,
     modifier: Modifier = Modifier
 ) {
-    Text(
-        text = text,
-        fontSize = 18.sp,
-        textAlign = TextAlign.Center,
+    Card(
+        shape = CircleShape,
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         modifier = modifier.offset(y = (-32).dp)
-    )
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(4.dp)
+        ) {
+            Text(
+                text = text,
+                fontSize = 18.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -50,7 +50,7 @@ fun NotationKeyButton(
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,
-                    onClick = { onTextInput("$inputKey ") }
+                    onClick = { onTextInput("$key ") }
                 )
                 .draggable(
                     interactionSource = interactionSource,
@@ -85,8 +85,10 @@ fun NotationKeyButton(
             text = key.toString()
         )
 
-        if (isPressed || isDragged) {
+        if (isPressed) {
             Text(text = key.toString())
+        } else if (isDragged) {
+            Text(text = inputKey.toString())
         }
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/composables/NotationKeyButton.kt
@@ -1,5 +1,10 @@
 package com.rickyhu.hushkeyboard.ui.composables
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -8,14 +13,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.rickyhu.hushkeyboard.model.CubeKey
 import com.rickyhu.hushkeyboard.model.Notation
 import com.rickyhu.hushkeyboard.model.Turns
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
-import kotlin.math.abs
 
 @Composable
 fun NotationKeyButton(
@@ -23,50 +26,45 @@ fun NotationKeyButton(
     cubeKey: CubeKey,
     onTextInput: (String) -> Unit = {}
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     val key by rememberUpdatedState(cubeKey)
     var inputKey by remember { mutableStateOf(key) }
 
     KeyButton(
         modifier = modifier
-            .pointerInput(key) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        val position = event.changes.first().position
-
-                        when (event.type.toString()) {
-                            "Press" -> {
-                                inputKey = key
-                            }
-
-                            "Move" -> {
-                                if (abs(position.x) < abs(position.y)) {
-                                    // Notate as double turn when swiping up or down, but only
-                                    // if the key state is originally a single turn.
-                                    val turns = if (key.turns == Turns.Single) {
-                                        Turns.Double
-                                    } else {
-                                        key.turns
-                                    }
-
-                                    // Clockwise down, counter-clockwise up.
-                                    inputKey = key.copy(
-                                        isCounterClockwise = position.y < 0,
-                                        turns = turns
-                                    )
-                                } else {
-                                    // Clockwise right, counter-clockwise left.
-                                    inputKey = key.copy(isCounterClockwise = position.x < 0)
-                                }
-                            }
-
-                            "Release" -> {
-                                onTextInput("$inputKey ")
-                            }
-                        }
-                    }
+            .clickable(interactionSource = interactionSource, indication = null) {
+                inputKey = key
+                onTextInput("$inputKey ")
+            }
+            .draggable(
+                interactionSource = interactionSource,
+                orientation = Orientation.Horizontal,
+                state = rememberDraggableState { x ->
+                    inputKey = key.copy(isCounterClockwise = x < 0)
+                },
+                onDragStopped = { x ->
+                    onTextInput("$inputKey ")
                 }
-            },
+            )
+            .draggable(
+                interactionSource = interactionSource,
+                orientation = Orientation.Vertical,
+                state = rememberDraggableState { y ->
+                    // Notate as double turn when swiping up or down, but only
+                    // if the key state is originally a single turn.
+                    val turns = if (key.turns == Turns.Single) {
+                        Turns.Double
+                    } else {
+                        key.turns
+                    }
+
+                    // Clockwise down, counter-clockwise up.
+                    inputKey = key.copy(isCounterClockwise = y < 0, turns = turns)
+                },
+                onDragStopped = { y ->
+                    onTextInput("$inputKey ")
+                }
+            ),
         text = key.toString()
     )
 }


### PR DESCRIPTION
## Description

This PR adds a `KeyTooltip` when a `NotationKeyButton` is clicked or dragged.

## How to verify 

Case 1: Verify if the tooltip shows the correct notation when `NotationKeyButton` is clicked.
Case 2: Verify if the tooltip shows the correct notation when `NotationKeyButton` is dragged. 

## Screenshots / Videos

### Case 1

https://github.com/ricky9667/HushKeyboard/assets/55730003/de4467f6-0564-4e18-9b01-e1f80d67d7a5

### Case 2

https://github.com/ricky9667/HushKeyboard/assets/55730003/5d83123e-9396-49c2-b46b-57fb41187dbf
