### PR TITLE
Create settings screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("com.google.devtools.ksp") version "1.8.10-1.0.9"
     id("org.jlleitschuh.gradle.ktlint") version "11.4.1"
 }
 
@@ -31,11 +32,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
@@ -68,6 +69,8 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("com.louiscad.splitties:splitties-systemservices:3.0.0")
+    implementation("io.github.raamcosta.compose-destinations:core:1.8.42-beta")
+    ksp("io.github.raamcosta.compose-destinations:ksp:1.8.42-beta")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("com.louiscad.splitties:splitties-systemservices:3.0.0")
+    implementation("com.github.alorma:compose-settings-ui-m3:0.27.0")
     implementation("io.github.raamcosta.compose-destinations:core:1.8.42-beta")
     ksp("io.github.raamcosta.compose-destinations:ksp:1.8.42-beta")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/rickyhu/hushkeyboard/MainActivity.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/MainActivity.kt
@@ -7,7 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import com.rickyhu.hushkeyboard.ui.home.HomeScreen
+import com.ramcosta.composedestinations.DestinationsNavHost
+import com.rickyhu.hushkeyboard.ui.NavGraphs
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,7 +20,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    HomeScreen()
+                    DestinationsNavHost(navGraph = NavGraphs.root)
                 }
             }
         }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/home/HomeScreen.kt
@@ -43,21 +43,30 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.rickyhu.hushkeyboard.R
+import com.rickyhu.hushkeyboard.ui.destinations.SettingsScreenDestination
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 import splitties.systemservices.inputMethodManager
 
+@Destination(start = true)
+@Composable
+fun HomeScreen(navigator: DestinationsNavigator) {
+    HomeContent(onSettingsClick = { navigator.navigate(SettingsScreenDestination()) })
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen() {
+private fun HomeContent(
+    onSettingsClick: () -> Unit = {}
+) {
     val context = LocalContext.current
     var text by remember { mutableStateOf("") }
 
     Scaffold(
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = {}
-            ) {
+            FloatingActionButton(onClick = onSettingsClick) {
                 Icon(Icons.Default.Settings, contentDescription = "Settings")
             }
         },
@@ -129,6 +138,6 @@ fun HomeScreen() {
 @Composable
 fun HomeScreenPreview() {
     HushKeyboardTheme {
-        HomeScreen()
+        HomeContent()
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
@@ -8,12 +8,12 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.ramcosta.composedestinations.annotation.Destination
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
+@Destination
 @Composable
-fun SettingsScreen() {
-    SettingsContent()
-}
+fun SettingsScreen() = SettingsContent()
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
@@ -1,0 +1,37 @@
+package com.rickyhu.hushkeyboard.ui.settings
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
+
+@Composable
+fun SettingsScreen() {
+    SettingsContent()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsContent() {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Settings") })
+        },
+        content = { padding ->
+            Text("Settings", modifier = Modifier.padding(padding))
+        }
+    )
+}
+
+@Preview
+@Composable
+fun SettingsScreenPreview() {
+    HushKeyboardTheme {
+        SettingsContent()
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
@@ -1,13 +1,21 @@
 package com.rickyhu.hushkeyboard.ui.settings
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import com.alorma.compose.settings.ui.SettingsMenuLink
 import com.ramcosta.composedestinations.annotation.Destination
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
@@ -18,12 +26,25 @@ fun SettingsScreen() = SettingsContent()
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsContent() {
+    val context = LocalContext.current
+
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Settings") })
         },
         content = { padding ->
-            Text("Settings", modifier = Modifier.padding(padding))
+            Column(modifier = Modifier.padding(padding)) {
+                SettingsMenuLink(
+                    icon = { Icon(imageVector = Icons.Default.Info, contentDescription = "Info") },
+                    title = { Text("Version") },
+                    subtitle = { Text("v0.1.0") },
+                    onClick = {
+                        val url = "https://github.com/ricky9667/HushKeyboard"
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                        context.startActivity(intent)
+                    }
+                )
+            }
         }
     )
 }


### PR DESCRIPTION
## Description

This PR creates the `SettingsScreen` of the app, which includes a menu link that shows the version of the app, and links to the Github repository when clicked.

### Implementation details

- Applies [compose-destinations](https://github.com/raamcosta/compose-destinations) for app navigation
- Builds settings page with [Compose-Settings](https://github.com/alorma/Compose-Settings)

## How to verify

- Verify if `SettingsScreen` is shown when the FAB in `HomeScreen` is clicked
- Verify if the `Version` item opens the Github repository of this app.

## Screenshots /  Videos

https://github.com/ricky9667/HushKeyboard/assets/55730003/744abfa4-d7a0-4153-bbc8-afd994a98f1d

