### PR TITLE
Integrate add blank after input to settings

### DIFF
--- a/app/src/main/java/com/rickyhu/hushkeyboard/MainActivity.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/MainActivity.kt
@@ -12,8 +12,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.rickyhu.hushkeyboard.settings.AppSettings
+import com.rickyhu.hushkeyboard.settings.dataStore
 import com.rickyhu.hushkeyboard.ui.NavGraphs
-import com.rickyhu.hushkeyboard.ui.keyboard.dataStore
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/rickyhu/hushkeyboard/model/CubeKey.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/model/CubeKey.kt
@@ -15,4 +15,9 @@ data class CubeKey(
 
         return result
     }
+
+    fun asText(addSpaceAfterNotation: Boolean): String {
+        val result = toString()
+        return if (addSpaceAfterNotation) "$result " else result
+    }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/AppSettings.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/AppSettings.kt
@@ -1,6 +1,10 @@
 package com.rickyhu.hushkeyboard.settings
 
+import android.content.Context
+import androidx.datastore.dataStore
 import kotlinx.serialization.Serializable
+
+val Context.dataStore by dataStore("app-settings.json", AppSettingsSerializer)
 
 @Serializable
 data class AppSettings(

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/AppSettings.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/AppSettings.kt
@@ -4,7 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class AppSettings(
-    val themeOption: ThemeOption = ThemeOption.System
+    val themeOption: ThemeOption = ThemeOption.System,
+    val addSpaceAfterNotation: Boolean = true
 )
 
 enum class ThemeOption {

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/ControlKeyButtonRow.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/ControlKeyButtonRow.kt
@@ -61,7 +61,7 @@ fun ControlKeyButtonRow(
             content = {
                 Text(
                     "'",
-                    color = if (isDarkTheme) Color.White else Color.Black,
+                    color = keyColor,
                     fontSize = 18.sp,
                     textAlign = TextAlign.Center
                 )
@@ -114,7 +114,7 @@ fun ControlKeyButtonRow(
                 Icon(
                     painter = painterResource(R.drawable.ic_return),
                     tint = keyColor,
-                    contentDescription = "Language"
+                    contentDescription = "Return"
                 )
             }
         )

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/HushKeyboard.kt
@@ -50,6 +50,7 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
                 keyboardState.isWideTurn
             ),
             isDarkTheme = isDarkTheme,
+            addSpaceAfterNotation = settingsState.addSpaceAfterNotation,
             onTextInput = { text -> viewModel.inputText(context, text) }
         )
 
@@ -59,6 +60,7 @@ fun HushKeyboard(viewModel: KeyboardViewModel) {
                 keyboardState.turns
             ),
             isDarkTheme = isDarkTheme,
+            addSpaceAfterNotation = settingsState.addSpaceAfterNotation,
             onTextInput = { text -> viewModel.inputText(context, text) }
         )
 

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/HushKeyboard.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/HushKeyboard.kt
@@ -1,6 +1,5 @@
 package com.rickyhu.hushkeyboard.ui.keyboard
 
-import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
@@ -15,15 +14,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.datastore.dataStore
 import com.rickyhu.hushkeyboard.model.NotationKeyProvider
 import com.rickyhu.hushkeyboard.settings.AppSettings
-import com.rickyhu.hushkeyboard.settings.AppSettingsSerializer
+import com.rickyhu.hushkeyboard.settings.dataStore
 import com.rickyhu.hushkeyboard.ui.theme.DarkBackground
 import com.rickyhu.hushkeyboard.ui.theme.LightBackground
 import com.rickyhu.hushkeyboard.viewmodel.KeyboardViewModel
-
-val Context.dataStore by dataStore("app-settings.json", AppSettingsSerializer)
 
 @RequiresApi(Build.VERSION_CODES.S)
 @Composable

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/NotationKeyButtonRow.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/NotationKeyButtonRow.kt
@@ -15,6 +15,7 @@ import com.rickyhu.hushkeyboard.ui.keyboard.buttons.NotationKeyButton
 fun NotationKeyButtonsRow(
     keys: List<CubeKey>,
     isDarkTheme: Boolean = false,
+    addSpaceAfterNotation: Boolean,
     onTextInput: (String) -> Unit
 ) {
     Row(
@@ -28,6 +29,7 @@ fun NotationKeyButtonsRow(
                     .size(48.dp),
                 cubeKey = key,
                 isDarkTheme = isDarkTheme,
+                addSpaceAfterNotation = addSpaceAfterNotation,
                 onTextInput = onTextInput
             )
         }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/buttons/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/keyboard/buttons/NotationKeyButton.kt
@@ -43,6 +43,7 @@ fun NotationKeyButton(
     modifier: Modifier = Modifier,
     cubeKey: CubeKey,
     isDarkTheme: Boolean,
+    addSpaceAfterNotation: Boolean,
     onTextInput: (String) -> Unit = {}
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -66,7 +67,7 @@ fun NotationKeyButton(
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,
-                    onClick = { onTextInput("$key ") }
+                    onClick = { onTextInput(key.asText(addSpaceAfterNotation)) }
                 )
                 .draggable(
                     interactionSource = interactionSource,
@@ -76,7 +77,7 @@ fun NotationKeyButton(
                         inputKey = key.copy(isCounterClockwise = offsetX < 0)
                     },
                     onDragStarted = { offsetX = 0f },
-                    onDragStopped = { onTextInput("$inputKey ") }
+                    onDragStopped = { onTextInput(inputKey.asText(addSpaceAfterNotation)) }
                 )
                 .draggable(
                     interactionSource = interactionSource,
@@ -84,8 +85,8 @@ fun NotationKeyButton(
                     state = rememberDraggableState { y ->
                         offsetY += y
 
-                        // Notate as double turn when swiping up or down, but only
-                        // if the key state is originally a single turn.
+                        // Notate as double turn when swiping up or down, but only if the key state
+                        // is originally a single turn.
                         val turns = if (key.turns == Turns.Single) {
                             Turns.Double
                         } else {
@@ -96,7 +97,7 @@ fun NotationKeyButton(
                         inputKey = key.copy(isCounterClockwise = offsetY < 0, turns = turns)
                     },
                     onDragStarted = { offsetY = 0f },
-                    onDragStopped = { onTextInput("$inputKey ") }
+                    onDragStopped = { onTextInput(inputKey.asText(addSpaceAfterNotation)) }
                 ),
             buttonColor = if (isDarkTheme) DarkPrimary else LightPrimary,
             content = {
@@ -162,7 +163,8 @@ fun NotationKeyButtonPreview() {
                 .padding(4.dp)
                 .size(48.dp),
             cubeKey = CubeKey(notation = Notation.R),
-            isDarkTheme = false
+            isDarkTheme = false,
+            addSpaceAfterNotation = true
         )
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import com.ramcosta.composedestinations.annotation.Destination
 import com.rickyhu.hushkeyboard.settings.AppSettings
-import com.rickyhu.hushkeyboard.ui.keyboard.dataStore
+import com.rickyhu.hushkeyboard.settings.dataStore
 import com.rickyhu.hushkeyboard.ui.settings.composables.AddSpaceBetweenNotationSwitchItem
 import com.rickyhu.hushkeyboard.ui.settings.composables.AppVersionItem
 import com.rickyhu.hushkeyboard.ui.settings.composables.SystemThemeDropdownItem

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.ramcosta.composedestinations.annotation.Destination
 import com.rickyhu.hushkeyboard.settings.AppSettings
 import com.rickyhu.hushkeyboard.ui.keyboard.dataStore
+import com.rickyhu.hushkeyboard.ui.settings.composables.AddSpaceBetweenNotationSwitchItem
 import com.rickyhu.hushkeyboard.ui.settings.composables.AppVersionItem
 import com.rickyhu.hushkeyboard.ui.settings.composables.SystemThemeDropdownItem
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
@@ -48,6 +49,16 @@ private fun SettingsContent(
                         coroutineScope.launch {
                             context.dataStore.updateData { settings ->
                                 settings.copy(themeOption = themeOption)
+                            }
+                        }
+                    }
+                )
+                AddSpaceBetweenNotationSwitchItem(
+                    value = settings.addSpaceAfterNotation,
+                    onValueChanged = { addSpaceAfterNotation ->
+                        coroutineScope.launch {
+                            context.dataStore.updateData { settings ->
+                                settings.copy(addSpaceAfterNotation = addSpaceAfterNotation)
                             }
                         }
                     }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/AddSpaceBetweenNotationSwitchItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/AddSpaceBetweenNotationSwitchItem.kt
@@ -1,0 +1,37 @@
+package com.rickyhu.hushkeyboard.ui.settings.composables
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddSpaceBetweenNotationSwitchItem(
+    value: Boolean,
+    onValueChanged: (Boolean) -> Unit = {}
+) {
+    ListItem(
+        headlineText = { Text("Add space after notation") },
+        leadingContent = { Icon(imageVector = Icons.Default.Info, contentDescription = "Info") },
+        trailingContent = {
+            Switch(checked = value, onCheckedChange = onValueChanged)
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AddSpaceBetweenNotationSwitchItemPreview() {
+    HushKeyboardTheme {
+        AddSpaceBetweenNotationSwitchItem(
+            value = true
+        )
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/AddSpaceBetweenNotationSwitchItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/AddSpaceBetweenNotationSwitchItem.kt
@@ -1,11 +1,13 @@
 package com.rickyhu.hushkeyboard.ui.settings.composables
 
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rickyhu.hushkeyboard.R
@@ -18,6 +20,7 @@ fun AddSpaceBetweenNotationSwitchItem(
     onValueChanged: (Boolean) -> Unit = {}
 ) {
     ListItem(
+        modifier = Modifier.clickable { onValueChanged(!value) },
         headlineText = { Text("Add space after notation") },
         leadingContent = {
             Icon(

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/AddSpaceBetweenNotationSwitchItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/AddSpaceBetweenNotationSwitchItem.kt
@@ -1,14 +1,14 @@
 package com.rickyhu.hushkeyboard.ui.settings.composables
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.rickyhu.hushkeyboard.R
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -19,7 +19,12 @@ fun AddSpaceBetweenNotationSwitchItem(
 ) {
     ListItem(
         headlineText = { Text("Add space after notation") },
-        leadingContent = { Icon(imageVector = Icons.Default.Info, contentDescription = "Info") },
+        leadingContent = {
+            Icon(
+                painter = painterResource(R.drawable.ic_space),
+                contentDescription = "Space"
+            )
+        },
         trailingContent = {
             Switch(checked = value, onCheckedChange = onValueChanged)
         }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/SystemThemeDropdownItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/composables/SystemThemeDropdownItem.kt
@@ -1,8 +1,6 @@
 package com.rickyhu.hushkeyboard.ui.settings.composables
 
 import androidx.compose.foundation.clickable
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -15,7 +13,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.rickyhu.hushkeyboard.R
 import com.rickyhu.hushkeyboard.settings.ThemeOption
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
@@ -31,7 +31,10 @@ fun SystemThemeDropdownItem(
         modifier = Modifier.clickable { expanded = true },
         headlineText = { Text("System Theme") },
         leadingContent = {
-            Icon(imageVector = Icons.Default.Star, contentDescription = null)
+            Icon(
+                painter = painterResource(R.drawable.ic_brightness),
+                contentDescription = "Brightness"
+            )
         },
         trailingContent = {
             Text(text = currentTheme.name)

--- a/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/viewmodel/KeyboardViewModel.kt
@@ -57,7 +57,7 @@ class KeyboardViewModel : ViewModel() {
 
     fun inputText(context: Context, text: String) {
         val inputConnection = (context as HushIMEService).currentInputConnection
-        inputConnection.commitText(text, text.length)
+        inputConnection.commitText(text, CURSOR_POSITION)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             vibrate(context)
@@ -83,6 +83,10 @@ class KeyboardViewModel : ViewModel() {
                     .compose()
             )
         )
+    }
+
+    companion object {
+        private const val CURSOR_POSITION = 1
     }
 }
 

--- a/app/src/main/res/drawable/ic_brightness.xml
+++ b/app/src/main/res/drawable/ic_brightness.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,15.31L23.31,12 20,8.69V4h-4.69L12,0.69 8.69,4H4v4.69L0.69,12 4,15.31V20h4.69L12,23.31 15.31,20H20v-4.69zM12,18V6c3.31,0 6,2.69 6,6s-2.69,6 -6,6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_space.xml
+++ b/app/src/main/res/drawable/ic_space.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,9v4H6V9H4v6h16V9z"/>
+</vector>


### PR DESCRIPTION
## Description

### Feature

- Add settings item that change if input adds blank after notation
- Change settings item leading icons

### Improvements

- Fix cursor incorrectly located

## How to verify

1. Check  "Add  space after notation" can switch when tapping the item and the switch
2. Check keyboard does not add space when switch is off
3. Check Settings items show correctly 

## Screenshots /  Videos

| Light | Dark |
| --- | --- |
| ![Screenshot_20240210_155014](https://github.com/ricky9667/HushKeyboard/assets/55730003/de2aed2b-eaf0-4839-906b-77aa494c4d90) |  ![Screenshot_20240210_155031](https://github.com/ricky9667/HushKeyboard/assets/55730003/06f76570-9f57-4859-854f-e5aedda1c3d7) | 

https://github.com/ricky9667/HushKeyboard/assets/55730003/ec5abddf-95e4-4bf5-9dec-b02fd58c87f1