### PR TITLE
Use original compose navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.ksp)
     alias(libs.plugins.ktlint)
     id("org.jetbrains.kotlin.plugin.serialization")
 }
@@ -65,6 +64,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.service)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.navigation.compose)
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.espresso.core)
 
@@ -86,10 +86,6 @@ dependencies {
     // Data Store
     implementation(libs.androidx.datastore)
     implementation(libs.kotlinx.serialization.json)
-
-    // Compose Destinations
-    ksp(libs.compose.destinations.ksp)
-    implementation(libs.compose.destinations.core)
 
     // Testing
     testImplementation(libs.junit)

--- a/app/src/main/java/com/rickyhu/hushkeyboard/MainActivity.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/MainActivity.kt
@@ -10,10 +10,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import com.ramcosta.composedestinations.DestinationsNavHost
+import com.rickyhu.hushkeyboard.navigation.AppNavHost
 import com.rickyhu.hushkeyboard.settings.AppSettings
 import com.rickyhu.hushkeyboard.settings.dataStore
-import com.rickyhu.hushkeyboard.ui.NavGraphs
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 
 class MainActivity : ComponentActivity() {
@@ -34,7 +33,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    DestinationsNavHost(navGraph = NavGraphs.root)
+                    AppNavHost()
                 }
             }
         }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/navigation/AppNavHost.kt
@@ -1,0 +1,15 @@
+package com.rickyhu.hushkeyboard.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun AppNavHost() {
+    val navController = rememberNavController()
+
+    NavHost(navController = navController, startDestination = homeRoute) {
+        homeScreen(onSettingsClick = { navController.navigateToSettings() })
+        settingsScreen()
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/navigation/HomeRoute.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/navigation/HomeRoute.kt
@@ -1,0 +1,19 @@
+package com.rickyhu.hushkeyboard.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.rickyhu.hushkeyboard.ui.home.HomeScreen
+
+const val homeRoute = "home"
+
+fun NavController.navigateToHome(navOptions: NavOptions? = null) {
+    this.navigate(homeRoute, navOptions)
+}
+
+fun NavGraphBuilder.homeScreen(onSettingsClick: () -> Unit) {
+    composable(route = homeRoute) {
+        HomeScreen(onSettingsClick)
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/navigation/SettingsRoute.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/navigation/SettingsRoute.kt
@@ -1,0 +1,19 @@
+package com.rickyhu.hushkeyboard.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import com.rickyhu.hushkeyboard.ui.settings.SettingsScreen
+
+const val settingsRoute = "settings"
+
+fun NavController.navigateToSettings(navOptions: NavOptions? = null) {
+    this.navigate(settingsRoute, navOptions)
+}
+
+fun NavGraphBuilder.settingsScreen() {
+    composable(route = settingsRoute) {
+        SettingsScreen()
+    }
+}

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/home/HomeScreen.kt
@@ -42,21 +42,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.rickyhu.hushkeyboard.R
-import com.rickyhu.hushkeyboard.ui.destinations.SettingsScreenDestination
 import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 import splitties.systemservices.inputMethodManager
 
-@Destination(start = true)
 @Composable
-fun HomeScreen(navigator: DestinationsNavigator) {
-    HomeContent(onSettingsClick = { navigator.navigate(SettingsScreenDestination()) })
-}
-
-@Composable
-private fun HomeContent(
+fun HomeScreen(
     onSettingsClick: () -> Unit = {}
 ) {
     val context = LocalContext.current
@@ -136,6 +127,6 @@ private fun HomeContent(
 @Composable
 fun HomeScreenPreview() {
     HushKeyboardTheme {
-        HomeContent()
+        HomeScreen()
     }
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/ui/settings/SettingsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
-import com.ramcosta.composedestinations.annotation.Destination
 import com.rickyhu.hushkeyboard.settings.AppSettings
 import com.rickyhu.hushkeyboard.settings.dataStore
 import com.rickyhu.hushkeyboard.ui.settings.composables.AddSpaceBetweenNotationSwitchItem
@@ -27,13 +26,9 @@ import com.rickyhu.hushkeyboard.ui.theme.HushKeyboardTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@Destination
-@Composable
-fun SettingsScreen() = SettingsContent()
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SettingsContent(
+fun SettingsScreen(
     coroutineScope: CoroutineScope = rememberCoroutineScope()
 ) {
     val context = LocalContext.current
@@ -101,6 +96,6 @@ private fun SettingsContent(
 @Composable
 fun SettingsScreenPreview() {
     HushKeyboardTheme {
-        SettingsContent()
+        SettingsScreen()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,17 +2,16 @@
 activity-compose = "1.8.2"
 android-gradle-plugin = "8.1.1"
 compose-bom = "2024.02.00"
-compose-destinations = "1.8.42-beta"
 core-ktx = "1.12.0"
 datastore = "1.0.0"
 espresso-core = "3.5.0"
+junit = "4.13.2"
+junit-ext = "1.1.5"
 kotlin = "1.8.10"
 kotlin-serialization = "1.8.10"
 kotlinx-serialization-json = "1.3.2"
 ktlint = "11.4.1"
-ksp = "1.8.10-1.0.9"
-junit = "4.13.2"
-junit-ext = "1.1.5"
+navigation-compose = "2.7.7"
 lifecycle-runtime-ktx = "2.7.0"
 lifecycle-service = "2.7.0"
 splitties-systemservices = "3.0.0"
@@ -27,14 +26,12 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit", version.ref = "junit-ext" }
-compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "compose-destinations" }
-compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destinations" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-serialization = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin-serialization" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
@@ -43,5 +40,4 @@ splitties-systemservices = { group = "com.louiscad.splitties", name = "splitties
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
## Description

This PR removes the usage of [compose-destinations](https://github.com/raamcosta/compose-destinations) and applies the original compose navigation.

Followed best practices from [this video](https://youtu.be/goFpG25uoc8?si=dUWJ108y-FCMdyYL) and [Now in Android](https://github.com/android/nowinandroid/tree/main?tab=readme-ov-file)

## How to verify

Check if navigation works as is.

## Screenshots /  Videos

N/A