### PR TITLE
Add basic UI tests for all views

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Android CI
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/HushKeyboardView.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/HushKeyboardView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Build
 import android.os.VibratorManager
 import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
@@ -48,8 +49,9 @@ class HushKeyboardView(context: Context) : AbstractComposeView(context) {
     }
 }
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @Composable
-private fun HushKeyboardContent(state: KeyboardState) {
+fun HushKeyboardContent(state: KeyboardState) {
     val context = LocalContext.current
 
     val vibratorManager = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/ui/buttons/NotationKeyButton.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/ui/buttons/NotationKeyButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -51,8 +52,8 @@ fun NotationKeyButton(
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
     val isDragged by interactionSource.collectIsDraggedAsState()
-    var offsetX by remember { mutableStateOf(0f) }
-    var offsetY by remember { mutableStateOf(0f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
+    var offsetY by remember { mutableFloatStateOf(0f) }
 
     val key by rememberUpdatedState(cubeKey)
     var inputKey by remember { mutableStateOf(key) }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/SettingsScreen.kt
@@ -2,6 +2,7 @@ package com.rickyhu.hushkeyboard.settings
 
 import android.content.Intent
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -39,9 +40,10 @@ fun SettingsScreen(
     )
 }
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SettingsContent(
+fun SettingsContent(
     state: SettingsState,
     onThemeSelected: (themeOption: ThemeOption) -> Unit,
     onWideNotationOptionSelected: (wideNotationOption: WideNotationOption) -> Unit,

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/ThemeOptionDropdownItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/ThemeOptionDropdownItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rickyhu.hushkeyboard.R
@@ -38,6 +39,7 @@ fun ThemeOptionDropdownItem(
             Text(text = currentTheme.name)
 
             DropdownMenu(
+                modifier = Modifier.testTag("ThemeOptionDropdownMenu"),
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
             ) {

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/ThemeOptionDropdownItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/ThemeOptionDropdownItem.kt
@@ -45,6 +45,7 @@ fun ThemeOptionDropdownItem(
             ) {
                 for (option in ThemeOption.values()) {
                     DropdownMenuItem(
+                        modifier = Modifier.testTag("ThemeOptionDropdownMenuItem"),
                         text = { Text(option.name) },
                         onClick = {
                             onThemeSelected(option)

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -1,0 +1,31 @@
+package com.rickyhu.hushkeyboard.ui
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.rickyhu.hushkeyboard.keyboard.HushKeyboardContent
+import com.rickyhu.hushkeyboard.keyboard.KeyboardState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HushKeyboardUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `First row key should exist, should be enabled, and should have click action`() {
+        composeTestRule.setContent {
+            HushKeyboardContent(state = KeyboardState())
+        }
+
+        composeTestRule
+            .onNodeWithText("R ")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
+}

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -1,9 +1,12 @@
 package com.rickyhu.hushkeyboard.ui
 
+import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -52,5 +55,16 @@ class SettingsScreenUiTest {
             .onNodeWithTag("ThemeOptionDropdownMenu")
             .assertIsEnabled()
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun `All AppThemeDropdownMenuItems should display after AppThemeDropdownItem is clicked`() {
+        composeTestRule
+            .onNodeWithText("App Theme")
+            .performClick()
+
+        composeTestRule
+            .onAllNodesWithTag("ThemeOptionDropdownMenuItem")
+            .assertAll(isEnabled())
     }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -1,9 +1,12 @@
 package com.rickyhu.hushkeyboard.ui
 
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.rickyhu.hushkeyboard.settings.SettingsContent
 import com.rickyhu.hushkeyboard.settings.SettingsState
 import org.junit.Before
@@ -37,5 +40,17 @@ class SettingsScreenUiTest {
             .assertExists()
             .assertIsEnabled()
             .assertHasClickAction()
+    }
+
+    @Test
+    fun `AppThemeDropdownMenu should display after AppThemeDropdownItem is clicked`() {
+        composeTestRule
+            .onNodeWithText("App Theme")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("ThemeOptionDropdownMenu")
+            .assertIsEnabled()
+            .assertIsDisplayed()
     }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -1,0 +1,41 @@
+package com.rickyhu.hushkeyboard.ui
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.rickyhu.hushkeyboard.settings.SettingsContent
+import com.rickyhu.hushkeyboard.settings.SettingsState
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SettingsScreenUiTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        composeTestRule.setContent {
+            SettingsContent(
+                state = SettingsState(),
+                onThemeSelected = {},
+                onWideNotationOptionSelected = {},
+                onAddSpaceBetweenNotationChanged = {},
+                onVibrateOnTapChanged = {}
+            )
+        }
+    }
+
+    @Test
+    fun `App theme dropdown item should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithText("App Theme")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
+}


### PR DESCRIPTION
## Description

This PR adds basic test cases for `SettingsScreen` and `HushKeyboardView`.

## How to verify

1. All test cases pass in Github Actions.

## Screenshots /  Videos

N/A