### PR TITLE
Add keyboard view first row keys UI tests

### DIFF
--- a/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/HushKeyboardView.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/HushKeyboardView.kt
@@ -105,7 +105,7 @@ fun HushKeyboardContent(state: KeyboardState) {
             },
             rotateDirectionButtonAction = {
                 keyConfigState = keyConfigState.copy(
-                    isCounterClockwise = keyConfigState.isCounterClockwise
+                    isCounterClockwise = !keyConfigState.isCounterClockwise
                 )
                 if (state.vibrateOnTap) vibratorManager?.maybeVibrate()
             },

--- a/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/ui/rows/ControlKeyButtonRow.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/ui/rows/ControlKeyButtonRow.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -68,7 +69,7 @@ fun ControlKeyButtonRow(
             }
         )
         ControlKeyButton(
-            modifier = controlKeyModifier,
+            modifier = controlKeyModifier.testTag("TurnDegreeButton"),
             onClick = turnDegreeButtonAction,
             isDarkTheme = isDarkTheme,
             content = {

--- a/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/ui/rows/ControlKeyButtonRow.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/keyboard/ui/rows/ControlKeyButtonRow.kt
@@ -56,7 +56,7 @@ fun ControlKeyButtonRow(
             }
         )
         ControlKeyButton(
-            modifier = controlKeyModifier,
+            modifier = controlKeyModifier.testTag("RotateDirectionButton"),
             onClick = rotateDirectionButtonAction,
             isDarkTheme = isDarkTheme,
             content = {
@@ -82,7 +82,7 @@ fun ControlKeyButtonRow(
             }
         )
         ControlKeyButton(
-            modifier = controlKeyModifier,
+            modifier = controlKeyModifier.testTag("WideTurnButton"),
             onClick = wideTurnButtonAction,
             isDarkTheme = isDarkTheme,
             content = {

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -3,6 +3,7 @@ package com.rickyhu.hushkeyboard.ui
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.rickyhu.hushkeyboard.keyboard.HushKeyboardContent
@@ -56,9 +57,38 @@ class HushKeyboardUiTest {
             .assertHasClickAction()
     }
 
+    @Test
+    fun `First row key should show correct turn degree after clicking turn degree button`() {
+        clickTurnDegreeButton()
+
+        composeTestRule
+            .onNodeWithText("R2 ")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+
+        clickTurnDegreeButton()
+
+        composeTestRule
+            .onNodeWithText("R3 ")
+            .assertExists()
+
+        clickTurnDegreeButton()
+
+        composeTestRule
+            .onNodeWithText("R ")
+            .assertExists()
+    }
+
     private fun clickCounterClockwiseButton() {
         composeTestRule
             .onNodeWithText("'")
+            .performClick()
+    }
+
+    private fun clickTurnDegreeButton() {
+        composeTestRule
+            .onNodeWithTag("TurnDegreeButton")
             .performClick()
     }
 

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -45,9 +45,26 @@ class HushKeyboardUiTest {
             .assertHasClickAction()
     }
 
+    @Test
+    fun `First row key should show w notation after clicking wide notation button`() {
+        clickWideNotationButton()
+
+        composeTestRule
+            .onNodeWithText("Rw ")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
+
     private fun clickCounterClockwiseButton() {
         composeTestRule
             .onNodeWithText("'")
+            .performClick()
+    }
+
+    private fun clickWideNotationButton() {
+        composeTestRule
+            .onNodeWithText("w")
             .performClick()
     }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.rickyhu.hushkeyboard.keyboard.HushKeyboardContent
 import com.rickyhu.hushkeyboard.keyboard.KeyboardState
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,12 +18,15 @@ class HushKeyboardUiTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    @Test
-    fun `First row key should exist, should be enabled, and should have click action`() {
+    @Before
+    fun setUp() {
         composeTestRule.setContent {
             HushKeyboardContent(state = KeyboardState())
         }
+    }
 
+    @Test
+    fun `First row key should exist, should be enabled, and should have click action`() {
         composeTestRule
             .onNodeWithText("R ")
             .assertExists()
@@ -32,18 +36,18 @@ class HushKeyboardUiTest {
 
     @Test
     fun `First row key should change state after clicking counter clockwise button`() {
-        composeTestRule.setContent {
-            HushKeyboardContent(state = KeyboardState())
-        }
-
-        composeTestRule
-            .onNodeWithText("'")
-            .performClick()
+        clickCounterClockwiseButton()
 
         composeTestRule
             .onNodeWithText("R' ")
             .assertExists()
             .assertIsEnabled()
             .assertHasClickAction()
+    }
+
+    private fun clickCounterClockwiseButton() {
+        composeTestRule
+            .onNodeWithText("'")
+            .performClick()
     }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -82,7 +82,7 @@ class HushKeyboardUiTest {
 
     private fun clickCounterClockwiseButton() {
         composeTestRule
-            .onNodeWithText("'")
+            .onNodeWithTag("RotateDirectionButton")
             .performClick()
     }
 
@@ -94,7 +94,7 @@ class HushKeyboardUiTest {
 
     private fun clickWideNotationButton() {
         composeTestRule
-            .onNodeWithText("w")
+            .onNodeWithTag("WideTurnButton")
             .performClick()
     }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -1,6 +1,7 @@
 package com.rickyhu.hushkeyboard.ui
 
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -28,56 +29,40 @@ class HushKeyboardUiTest {
 
     @Test
     fun `First row key should exist, should be enabled, and should have click action`() {
-        composeTestRule
-            .onNodeWithText("R ")
-            .assertExists()
-            .assertIsEnabled()
-            .assertHasClickAction()
+        keyButtonShouldBe("R ")
     }
 
     @Test
     fun `First row key should change state after clicking counter clockwise button`() {
         clickCounterClockwiseButton()
-
-        composeTestRule
-            .onNodeWithText("R' ")
-            .assertExists()
-            .assertIsEnabled()
-            .assertHasClickAction()
+        keyButtonShouldBe("R' ")
     }
 
     @Test
     fun `First row key should show w notation after clicking wide notation button`() {
         clickWideNotationButton()
-
-        composeTestRule
-            .onNodeWithText("Rw ")
-            .assertExists()
-            .assertIsEnabled()
-            .assertHasClickAction()
+        keyButtonShouldBe("Rw ")
     }
 
     @Test
     fun `First row key should show correct turn degree after clicking turn degree button`() {
         clickTurnDegreeButton()
+        keyButtonShouldBe("R2 ")
 
+        clickTurnDegreeButton()
+        keyButtonShouldBe("R3 ")
+
+        clickTurnDegreeButton()
+        keyButtonShouldBe("R ")
+    }
+
+    private fun keyButtonShouldBe(text: String) {
         composeTestRule
-            .onNodeWithText("R2 ")
+            .onNodeWithText(text)
             .assertExists()
             .assertIsEnabled()
+            .assertIsDisplayed()
             .assertHasClickAction()
-
-        clickTurnDegreeButton()
-
-        composeTestRule
-            .onNodeWithText("R3 ")
-            .assertExists()
-
-        clickTurnDegreeButton()
-
-        composeTestRule
-            .onNodeWithText("R ")
-            .assertExists()
     }
 
     private fun clickCounterClockwiseButton() {

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -33,9 +33,12 @@ class HushKeyboardUiTest {
     }
 
     @Test
-    fun `First row key should change state after clicking counter clockwise button`() {
+    fun `First row key should show ' notation after clicking counter clockwise button`() {
         clickCounterClockwiseButton()
         keyButtonShouldBe("R' ")
+
+        clickCounterClockwiseButton()
+        keyButtonShouldBe("R ")
     }
 
     @Test

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/HushKeyboardUiTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.rickyhu.hushkeyboard.keyboard.HushKeyboardContent
 import com.rickyhu.hushkeyboard.keyboard.KeyboardState
 import org.junit.Rule
@@ -24,6 +25,23 @@ class HushKeyboardUiTest {
 
         composeTestRule
             .onNodeWithText("R ")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun `First row key should change state after clicking counter clockwise button`() {
+        composeTestRule.setContent {
+            HushKeyboardContent(state = KeyboardState())
+        }
+
+        composeTestRule
+            .onNodeWithText("'")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithText("R' ")
             .assertExists()
             .assertIsEnabled()
             .assertHasClickAction()


### PR DESCRIPTION
## Description

This PR adds the following test cases:
1. First row key should exist, should be enabled, and should have click action.
2. First row key should show ' notation after clicking counter clockwise button.
3. First row key should show w notation after clicking wide notation button.
4. First row key should show correct turn degree after clicking turn degree button.

This PR also fixes the rotation direction not working issue.

## How to verify

1. All test cases should pass.
2. CI pipeline should pass.

## Screenshots /  Videos

N/A