### PR TITLE
Add settings screen UI tests

### DIFF
--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/AddSpaceBetweenNotationSwitchItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/AddSpaceBetweenNotationSwitchItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rickyhu.hushkeyboard.R
@@ -27,7 +28,11 @@ fun AddSpaceBetweenNotationSwitchItem(
             )
         },
         trailingContent = {
-            Switch(checked = value, onCheckedChange = onValueChanged)
+            Switch(
+                checked = value,
+                onCheckedChange = onValueChanged,
+                modifier = Modifier.testTag("AddSpaceAfterNotationSwitch")
+            )
         }
     )
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/VibrateOnTapSwitchItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/VibrateOnTapSwitchItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rickyhu.hushkeyboard.R
@@ -27,7 +28,11 @@ fun VibrateOnTapSwitchItem(
             )
         },
         trailingContent = {
-            Switch(checked = value, onCheckedChange = onValueChanged)
+            Switch(
+                checked = value,
+                onCheckedChange = onValueChanged,
+                modifier = Modifier.testTag("VibrateOnTapSwitch")
+            )
         }
     )
 }

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/WideNotationOptionDropdownItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/WideNotationOptionDropdownItem.kt
@@ -45,6 +45,7 @@ fun WideNotationOptionDropdownItem(
             ) {
                 for (option in WideNotationOption.values()) {
                     DropdownMenuItem(
+                        modifier = Modifier.testTag("WideNotationOptionDropdownMenuItem"),
                         text = { Text(option.toString()) },
                         onClick = {
                             onOptionSelected(option)

--- a/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/WideNotationOptionDropdownItem.kt
+++ b/app/src/main/java/com/rickyhu/hushkeyboard/settings/ui/WideNotationOptionDropdownItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.rickyhu.hushkeyboard.R
@@ -38,6 +39,7 @@ fun WideNotationOptionDropdownItem(
             Text(text = currentOption.toString())
 
             DropdownMenu(
+                modifier = Modifier.testTag("WideNotationOptionDropdownMenu"),
                 expanded = expanded,
                 onDismissRequest = { expanded = false }
             ) {

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -135,4 +135,13 @@ class SettingsScreenUiTest {
             .assertIsEnabled()
             .assertHasClickAction()
     }
+
+    @Test
+    fun `Version should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithText("Version")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -108,4 +108,13 @@ class SettingsScreenUiTest {
             .assertIsEnabled()
             .assertHasClickAction()
     }
+
+    @Test
+    fun `Auto space switch should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithTag("AddSpaceAfterNotationSwitch")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -170,6 +170,15 @@ class SettingsScreenUiTest {
     }
 
     @Test
+    fun `Vibrate On Tap Switch value should be false after it is clicked`() {
+        composeTestRule
+            .onNodeWithTag("VibrateOnTapSwitch")
+            .performClick()
+
+        assertFalse(vibrateOnTapSwitchValue)
+    }
+
+    @Test
     fun `Version should exist, should be enabled, and should have click action`() {
         composeTestRule
             .onNodeWithText("Version")

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -24,6 +24,7 @@ import org.robolectric.RobolectricTestRunner
 class SettingsScreenUiTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+
     private var addSpaceAfterNotationSwitchValue = true
     private var vibrateOnTapSwitchValue = true
 

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.rickyhu.hushkeyboard.settings.SettingsContent
 import com.rickyhu.hushkeyboard.settings.SettingsState
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -22,6 +23,7 @@ import org.robolectric.RobolectricTestRunner
 class SettingsScreenUiTest {
     @get:Rule
     val composeTestRule = createComposeRule()
+    private var addSpaceAfterNotationSwitchValue = true
 
     @Before
     fun setUp() {
@@ -30,7 +32,9 @@ class SettingsScreenUiTest {
                 state = SettingsState(),
                 onThemeSelected = {},
                 onWideNotationOptionSelected = {},
-                onAddSpaceBetweenNotationChanged = {},
+                onAddSpaceBetweenNotationChanged = {
+                    addSpaceAfterNotationSwitchValue = it
+                },
                 onVibrateOnTapChanged = {}
             )
         }
@@ -116,6 +120,14 @@ class SettingsScreenUiTest {
             .assertExists()
             .assertIsEnabled()
             .assertHasClickAction()
+    }
+
+    @Test
+    fun `Auto space switch value should be true in initial state`() {
+        composeTestRule
+            .onNodeWithTag("AddSpaceAfterNotationSwitch")
+
+        assertTrue(addSpaceAfterNotationSwitchValue)
     }
 
     @Test

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.rickyhu.hushkeyboard.settings.SettingsContent
 import com.rickyhu.hushkeyboard.settings.SettingsState
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -128,6 +129,15 @@ class SettingsScreenUiTest {
             .onNodeWithTag("AddSpaceAfterNotationSwitch")
 
         assertTrue(addSpaceAfterNotationSwitchValue)
+    }
+
+    @Test
+    fun `Auto space switch value should be false after it is clicked`() {
+        composeTestRule
+            .onNodeWithTag("AddSpaceAfterNotationSwitch")
+            .performClick()
+
+        assertFalse(addSpaceAfterNotationSwitchValue)
     }
 
     @Test

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -99,4 +99,13 @@ class SettingsScreenUiTest {
             .onAllNodesWithTag("WideNotationOptionDropdownMenuItem")
             .assertAll(isEnabled())
     }
+
+    @Test
+    fun `Add space after notation should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithText("Add space after notation")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -25,6 +25,7 @@ class SettingsScreenUiTest {
     @get:Rule
     val composeTestRule = createComposeRule()
     private var addSpaceAfterNotationSwitchValue = true
+    private var vibrateOnTapSwitchValue = true
 
     @Before
     fun setUp() {
@@ -36,7 +37,9 @@ class SettingsScreenUiTest {
                 onAddSpaceBetweenNotationChanged = {
                     addSpaceAfterNotationSwitchValue = it
                 },
-                onVibrateOnTapChanged = {}
+                onVibrateOnTapChanged = {
+                    vibrateOnTapSwitchValue = it
+                }
             )
         }
     }
@@ -156,6 +159,14 @@ class SettingsScreenUiTest {
             .assertExists()
             .assertIsEnabled()
             .assertHasClickAction()
+    }
+
+    @Test
+    fun `Vibrate On Tap Switch value should be true in initial state`() {
+        composeTestRule
+            .onNodeWithTag("VibrateOnTapSwitch")
+
+        assertTrue(vibrateOnTapSwitchValue)
     }
 
     @Test

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -126,4 +126,13 @@ class SettingsScreenUiTest {
             .assertIsEnabled()
             .assertHasClickAction()
     }
+
+    @Test
+    fun `Vibrate on tap switch should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithTag("VibrateOnTapSwitch")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -117,4 +117,13 @@ class SettingsScreenUiTest {
             .assertIsEnabled()
             .assertHasClickAction()
     }
+
+    @Test
+    fun `Vibrate on tap should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithText("Vibrate on tap")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -88,4 +88,15 @@ class SettingsScreenUiTest {
             .assertIsEnabled()
             .assertIsDisplayed()
     }
+
+    @Test
+    fun `All WideNotationDropdownMenuItems should display after WideNotationDropdown is clicked`() {
+        composeTestRule
+            .onNodeWithText("Wide notation")
+            .performClick()
+
+        composeTestRule
+            .onAllNodesWithTag("WideNotationOptionDropdownMenuItem")
+            .assertAll(isEnabled())
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -35,11 +35,11 @@ class SettingsScreenUiTest {
                 state = SettingsState(),
                 onThemeSelected = {},
                 onWideNotationOptionSelected = {},
-                onAddSpaceBetweenNotationChanged = {
-                    addSpaceAfterNotationSwitchValue = it
+                onAddSpaceBetweenNotationChanged = { value ->
+                    addSpaceAfterNotationSwitchValue = value
                 },
-                onVibrateOnTapChanged = {
-                    vibrateOnTapSwitchValue = it
+                onVibrateOnTapChanged = { value ->
+                    vibrateOnTapSwitchValue = value
                 }
             )
         }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -76,4 +76,16 @@ class SettingsScreenUiTest {
             .assertIsEnabled()
             .assertHasClickAction()
     }
+
+    @Test
+    fun `WideNotationDropdownMenu should display after WideNotationDropdownItem is clicked`() {
+        composeTestRule
+            .onNodeWithText("Wide notation")
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag("WideNotationOptionDropdownMenu")
+            .assertIsEnabled()
+            .assertIsDisplayed()
+    }
 }

--- a/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
+++ b/app/src/test/java/com/rickyhu/hushkeyboard/ui/SettingsScreenUiTest.kt
@@ -67,4 +67,13 @@ class SettingsScreenUiTest {
             .onAllNodesWithTag("ThemeOptionDropdownMenuItem")
             .assertAll(isEnabled())
     }
+
+    @Test
+    fun `Wide notation item should exist, should be enabled, and should have click action`() {
+        composeTestRule
+            .onNodeWithText("Wide notation")
+            .assertExists()
+            .assertIsEnabled()
+            .assertHasClickAction()
+    }
 }


### PR DESCRIPTION
## Description

This PR adds the following test cases:

  1. Wide notation dropdown item should exist, should be enable, and should have click action.
  2. Wide notation dropdown menu should display after Wide notation dropdown item is clicked.
  3. All wide notation dropdown menu items should display after Wide notation dropdown item is clicked.
  4. Add space after notation item should exist, should be enabled, and should have click action.
  5. Auto space switch should exist, should be enabled, and should have click action.
  6. Auto space switch value should be true in initial state.
  7. Auto space switch value should be false after it is clicked.
  8. Vibrate on tap should exist, should be enabled, and should have click action.
  9. Vibrate on tap switch should exist, should be enabled, and should have click action.
  10. Vibrate On Tap Switch value should be true in initial state.
  11. Vibrate On Tap Switch value should be false after it is clicked.
  12. Version should exist, should be enabled, and should have click action.

## How to verify
  1. All test cases should pass.
  2. CI pipeline should pass.

## Screenshots /  Videos
